### PR TITLE
change to a generic authentication example

### DIFF
--- a/examples/authentication/main.go
+++ b/examples/authentication/main.go
@@ -41,7 +41,6 @@ func main() {
 }
 
 func interceptor(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-	md := metadata.New(map[string]string{"api-key": "secret-key-*******"})
-	newCtx := metadata.NewOutgoingContext(ctx, md)
+	newCtx := metadata.AppendToOutgoingContext(ctx, "api-key", "secret-key-*******")
 	return invoker(newCtx, method, req, reply, cc, opts...)
 }


### PR DESCRIPTION
## Why is it better to change?

This implementation is superior because it is generic and can be used throughout the application's context, avoiding code repetition.