### PR TITLE
Change return type of ScrollPoints

### DIFF
--- a/qdrant/points.go
+++ b/qdrant/points.go
@@ -62,14 +62,15 @@ func (c *Client) Get(ctx context.Context, request *GetPoints) ([]*RetrievedPoint
 //   - request: The ScrollPoints request specifying the scroll parameters.
 //
 // Returns:
-//   - []*RetrievedPoint: A slice of retrieved points.
+//   - *ScrollResponse: A structure that contains a slice of retrieved points,
+//     the next offset, and the time spent to process.
 //   - error: An error if the operation fails.
-func (c *Client) Scroll(ctx context.Context, request *ScrollPoints) ([]*RetrievedPoint, error) {
+func (c *Client) Scroll(ctx context.Context, request *ScrollPoints) (*ScrollResponse, error) {
 	resp, err := c.GetPointsClient().Scroll(ctx, request)
 	if err != nil {
 		return nil, newQdrantErr(err, "Scroll", request.GetCollectionName())
 	}
-	return resp.GetResult(), nil
+	return resp, nil
 }
 
 // Updates vectors for points in a collection.

--- a/qdrant_test/points_test.go
+++ b/qdrant_test/points_test.go
@@ -118,11 +118,12 @@ func TestPointsClient(t *testing.T) {
 	})
 
 	t.Run("ScrollPoints", func(t *testing.T) {
-		points, err := client.Scroll(ctx, &qdrant.ScrollPoints{
+		scrollResp, err := client.Scroll(ctx, &qdrant.ScrollPoints{
 			CollectionName: collectionName,
 		})
 		require.NoError(t, err)
-		require.Len(t, points, 1)
+		require.Len(t, scrollResp.GetResult(), 1)
+		require.Nil(t, scrollResp.GetNextPageOffset())
 	})
 
 	t.Run("UpdateVectors", func(t *testing.T) {


### PR DESCRIPTION
Currently ScrollPoints do not provide next_offset, which makes it inconvenient to use. 