### PR TITLE
Check if server's and client's versions are compatible

### DIFF
--- a/qdrant/compare_versions.go
+++ b/qdrant/compare_versions.go
@@ -1,0 +1,93 @@
+package qdrant
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+)
+
+const fullVersionParts = 3
+const reducedVersionParts = 2
+const unknownVersion = "Unknown"
+
+type Version struct {
+	Major int
+	Minor int
+	Rest  string
+}
+
+func getServerVersion(clientConn *GrpcClient) string {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	healthCheckResult, err := clientConn.qdrant.HealthCheck(ctx, &HealthCheckRequest{})
+	if err != nil {
+		log.Printf("Unable to get server version: %v, server version defaults to `%s`", err, unknownVersion)
+		return unknownVersion
+	}
+	serverVersion := healthCheckResult.GetVersion()
+
+	return serverVersion
+}
+
+func removeLeadingNonNumeric(versionStr string) string {
+	return strings.TrimLeftFunc(versionStr, func(r rune) bool {
+		return !unicode.IsDigit(r)
+	})
+}
+
+// ParseVersion converts a version string "x.y.z" into a Version struct.
+func ParseVersion(versionStr string) (*Version, error) {
+	cleanedVersionStr := removeLeadingNonNumeric(versionStr)
+	parts := strings.SplitN(cleanedVersionStr, ".", fullVersionParts)
+	if len(parts) < reducedVersionParts {
+		return nil, fmt.Errorf("unable to parse version, expected format: x.y.z, found: %s", cleanedVersionStr)
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse major version: %w", err)
+	}
+
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse minor version: %w", err)
+	}
+
+	rest := ""
+	if len(parts) == fullVersionParts {
+		rest = parts[2]
+	}
+
+	return &Version{
+		Major: major,
+		Minor: minor,
+		Rest:  rest,
+	}, nil
+}
+
+func IsCompatible(clientVersion, serverVersion *string) bool {
+	if *clientVersion == *serverVersion {
+		return true
+	}
+
+	parsedClientVersion, err := ParseVersion(*clientVersion)
+	if err != nil {
+		log.Printf("Unable to compare versions: %v", err)
+		return false
+	}
+	parsedServerVersion, err := ParseVersion(*serverVersion)
+	if err != nil {
+		log.Printf("Unable to compare versions: %v", err)
+		return false
+	}
+	majorDiff := int(math.Abs(float64(parsedClientVersion.Major - parsedServerVersion.Major)))
+	if majorDiff >= 1 {
+		return false
+	}
+	return int(math.Abs(float64(parsedClientVersion.Minor-parsedServerVersion.Minor))) <= 1
+}

--- a/qdrant/compare_versions_test.go
+++ b/qdrant/compare_versions_test.go
@@ -1,0 +1,68 @@
+package qdrant
+
+import (
+	"testing"
+)
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected *Version
+		hasError bool
+	}{
+		{"v1.2.3", &Version{Major: 1, Minor: 2, Rest: "3"}, false},
+		{"1.2.3", &Version{Major: 1, Minor: 2, Rest: "3"}, false},
+		{"v1.2", &Version{Major: 1, Minor: 2, Rest: ""}, false},
+		{"1.2", &Version{Major: 1, Minor: 2, Rest: ""}, false},
+		{"v1.2.3.4", &Version{Major: 1, Minor: 2, Rest: "3.4"}, false},
+		{"", nil, true},
+		{"1", nil, true},
+		{"1.", nil, true},
+		{".1.", nil, true},
+		{"1.something.1", nil, true},
+	}
+
+	for _, test := range tests {
+		result, err := ParseVersion(test.input)
+		if (err != nil) != test.hasError {
+			t.Errorf("ParseVersion(%q) error = %v, wantErr %v", test.input, err, test.hasError)
+			continue
+		}
+		if !test.hasError && (result.Major != test.expected.Major ||
+			result.Minor != test.expected.Minor ||
+			result.Rest != test.expected.Rest) {
+			t.Errorf("ParseVersion(%q) = %v, want %v", test.input, result, test.expected)
+		}
+	}
+}
+
+func TestIsCompatible(t *testing.T) {
+	tests := []struct {
+		clientVersion string
+		serverVersion string
+		expected      bool
+	}{
+		{"1.9.3.dev0", "2.8.1.dev12-something", false},
+		{"1.9", "2.8", false},
+		{"1", "2", false},
+		{"1", "1", true},
+		{"1.9.0", "2.9.0", false},
+		{"1.1.0", "1.2.9", true},
+		{"1.2.7", "1.1.8.dev0", true},
+		{"1.2.1", "1.2.29", true},
+		{"1.2.0", "1.2.0", true},
+		{"1.2.0", "1.4.0", false},
+		{"1.4.0", "1.2.0", false},
+		{"1.9.0", "3.7.0", false},
+		{"3.0.0", "1.0.0", false},
+	}
+
+	for _, test := range tests {
+		clientVersion := test.clientVersion
+		serverVersion := test.serverVersion
+		result := IsCompatible(&clientVersion, &serverVersion)
+		if result != test.expected {
+			t.Errorf("IsCompatible(%q, %q) = %v, want %v", clientVersion, serverVersion, result, test.expected)
+		}
+	}
+}

--- a/qdrant/config.go
+++ b/qdrant/config.go
@@ -33,6 +33,8 @@ type Config struct {
 	TLSConfig *tls.Config
 	// Additional gRPC options to use for the connection.
 	GrpcOptions []grpc.DialOption
+	// Whether to check compatibility between server's version and client's. Defaults to false.
+	SkipCompatibilityCheck bool
 }
 
 // Internal method.

--- a/qdrant/grpc_client.go
+++ b/qdrant/grpc_client.go
@@ -2,7 +2,7 @@ package qdrant
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"os/exec"
 	"strings"
 
@@ -52,14 +52,16 @@ func NewGrpcClient(config *Config) (*GrpcClient, error) {
 
 	if !config.SkipCompatibilityCheck {
 		serverVersion := getServerVersion(newGrpcClientFromConn)
+		logger := slog.Default()
 		if serverVersion == unknownVersion {
-			log.Printf("Failed to obtain server version. " +
+			logger.Warn("Failed to obtain server version. " +
 				"Unable to check client-server compatibility. " +
 				"Set SkipCompatibilityCheck=true to skip version check.")
 		} else if !IsCompatible(&clientVersion, &serverVersion) {
-			log.Printf("Qdrant client version `%s` is incompatible with server version `%s`. "+
+			logger.Warn("Client version is not compatible with server version. "+
 				"Major versions should match and minor version difference must not exceed 1. "+
-				"Set SkipCompatibilityCheck=true to skip version check.", clientVersion, serverVersion)
+				"Set SkipCompatibilityCheck=true to skip version check.",
+				"clientVersion", clientVersion, "serverVersion", serverVersion)
 		}
 	}
 

--- a/qdrant/grpc_client.go
+++ b/qdrant/grpc_client.go
@@ -57,7 +57,7 @@ func NewGrpcClient(config *Config) (*GrpcClient, error) {
 			logger.Warn("Failed to obtain server version. " +
 				"Unable to check client-server compatibility. " +
 				"Set SkipCompatibilityCheck=true to skip version check.")
-		} else if !IsCompatible(&clientVersion, &serverVersion) {
+		} else if !IsCompatible(clientVersion, serverVersion) {
 			logger.Warn("Client version is not compatible with server version. "+
 				"Major versions should match and minor version difference must not exceed 1. "+
 				"Set SkipCompatibilityCheck=true to skip version check.",

--- a/qdrant_test/compare_versions_test.go
+++ b/qdrant_test/compare_versions_test.go
@@ -1,20 +1,22 @@
-package qdrant
+package qdrant_test
 
 import (
 	"testing"
+
+	"github.com/qdrant/go-client/qdrant"
 )
 
 func TestParseVersion(t *testing.T) {
 	tests := []struct {
 		input    string
-		expected *Version
+		expected *qdrant.Version
 		hasError bool
 	}{
-		{"v1.2.3", &Version{Major: 1, Minor: 2, Rest: "3"}, false},
-		{"1.2.3", &Version{Major: 1, Minor: 2, Rest: "3"}, false},
-		{"v1.2", &Version{Major: 1, Minor: 2, Rest: ""}, false},
-		{"1.2", &Version{Major: 1, Minor: 2, Rest: ""}, false},
-		{"v1.2.3.4", &Version{Major: 1, Minor: 2, Rest: "3.4"}, false},
+		{"v1.2.3", &qdrant.Version{Major: 1, Minor: 2, Rest: "3"}, false},
+		{"1.2.3", &qdrant.Version{Major: 1, Minor: 2, Rest: "3"}, false},
+		{"v1.2", &qdrant.Version{Major: 1, Minor: 2, Rest: ""}, false},
+		{"1.2", &qdrant.Version{Major: 1, Minor: 2, Rest: ""}, false},
+		{"v1.2.3.4", &qdrant.Version{Major: 1, Minor: 2, Rest: "3.4"}, false},
 		{"", nil, true},
 		{"1", nil, true},
 		{"1.", nil, true},
@@ -23,12 +25,12 @@ func TestParseVersion(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		result, err := ParseVersion(test.input)
+		result, err := qdrant.ParseVersion(test.input)
 		if (err != nil) != test.hasError {
 			t.Errorf("ParseVersion(%q) error = %v, wantErr %v", test.input, err, test.hasError)
 			continue
 		}
-		if !test.hasError && (result.Major != test.expected.Major ||
+		if !test.hasError && result != nil && (result.Major != test.expected.Major ||
 			result.Minor != test.expected.Minor ||
 			result.Rest != test.expected.Rest) {
 			t.Errorf("ParseVersion(%q) = %v, want %v", test.input, result, test.expected)
@@ -60,7 +62,7 @@ func TestIsCompatible(t *testing.T) {
 	for _, test := range tests {
 		clientVersion := test.clientVersion
 		serverVersion := test.serverVersion
-		result := IsCompatible(&clientVersion, &serverVersion)
+		result := qdrant.IsCompatible(&clientVersion, &serverVersion)
 		if result != test.expected {
 			t.Errorf("IsCompatible(%q, %q) = %v, want %v", clientVersion, serverVersion, result, test.expected)
 		}

--- a/qdrant_test/compare_versions_test.go
+++ b/qdrant_test/compare_versions_test.go
@@ -12,11 +12,11 @@ func TestParseVersion(t *testing.T) {
 		expected *qdrant.Version
 		hasError bool
 	}{
-		{"v1.2.3", &qdrant.Version{Major: 1, Minor: 2, Rest: "3"}, false},
-		{"1.2.3", &qdrant.Version{Major: 1, Minor: 2, Rest: "3"}, false},
-		{"v1.2", &qdrant.Version{Major: 1, Minor: 2, Rest: ""}, false},
-		{"1.2", &qdrant.Version{Major: 1, Minor: 2, Rest: ""}, false},
-		{"v1.2.3.4", &qdrant.Version{Major: 1, Minor: 2, Rest: "3.4"}, false},
+		{"v1.2.3", &qdrant.Version{Major: 1, Minor: 2}, false},
+		{"1.2.3", &qdrant.Version{Major: 1, Minor: 2}, false},
+		{"v1.2", &qdrant.Version{Major: 1, Minor: 2}, false},
+		{"1.2", &qdrant.Version{Major: 1, Minor: 2}, false},
+		{"v1.2.3.4", &qdrant.Version{Major: 1, Minor: 2}, false},
 		{"", nil, true},
 		{"1", nil, true},
 		{"1.", nil, true},
@@ -31,8 +31,7 @@ func TestParseVersion(t *testing.T) {
 			continue
 		}
 		if !test.hasError && result != nil && (result.Major != test.expected.Major ||
-			result.Minor != test.expected.Minor ||
-			result.Rest != test.expected.Rest) {
+			result.Minor != test.expected.Minor) {
 			t.Errorf("ParseVersion(%q) = %v, want %v", test.input, result, test.expected)
 		}
 	}
@@ -62,7 +61,7 @@ func TestIsCompatible(t *testing.T) {
 	for _, test := range tests {
 		clientVersion := test.clientVersion
 		serverVersion := test.serverVersion
-		result := qdrant.IsCompatible(&clientVersion, &serverVersion)
+		result := qdrant.IsCompatible(clientVersion, serverVersion)
 		if result != test.expected {
 			t.Errorf("IsCompatible(%q, %q) = %v, want %v", clientVersion, serverVersion, result, test.expected)
 		}


### PR DESCRIPTION
Send request to fetch server version during client init and compare with client version. 

Introduce a boolean param SkipCompatibilityCheck (false by default). If it is false -> check versions during client init and generate a warning if versions are not compatible. Compatible versions are the ones that differ by one, i.e client version 1.6.x is compatible with server versions 1.5.x and 1.7.x but not 1.4.x or 1.8.x.