### PR TITLE
ci: align golangci-lint.yml go version with go.mod

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "^1.25"
+          go-version: "^1.24"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:


### PR DESCRIPTION
### description 
align go version in ci workflow file  with `go.mod` file from `^1.25` to `1.24.0`