### PR TITLE
examples: return error instead of panic on client init to match the others

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -34,7 +34,7 @@ func run() error {
 		// GrpcOptions: []grpc.DialOption{},
 	})
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("could not create client: %w", err)
 	}
 	defer client.Close()
 	// Get a context for a minute


### PR DESCRIPTION
### description 
to match how every other error is being handled in the run() function, just swapped the panic with a wrapped error return on client creation failure 
