### PR TITLE
fix: surface server version probe error, add Config.Logger

### DIFF
--- a/qdrant/compare_versions.go
+++ b/qdrant/compare_versions.go
@@ -19,18 +19,15 @@ type Version struct {
 	Minor int
 }
 
-func getServerVersion(clientConn *GrpcClient, timeout time.Duration) string {
-	logger := slog.Default()
+func getServerVersion(clientConn *GrpcClient, timeout time.Duration) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	healthCheckResult, err := clientConn.qdrant.HealthCheck(ctx, &HealthCheckRequest{})
 	if err != nil {
-		logger.WarnContext(ctx, "Unable to get server version, use default", "err", err, "default", unknownVersion)
-		return unknownVersion
+		return "", fmt.Errorf("server health check failed: %w", err)
 	}
-	serverVersion := healthCheckResult.GetVersion()
 
-	return serverVersion
+	return healthCheckResult.GetVersion(), nil
 }
 
 func removeLeadingNonNumeric(versionStr string) string {
@@ -64,10 +61,15 @@ func ParseVersion(versionStr string) (*Version, error) {
 }
 
 func IsCompatible(clientVersion, serverVersion string) bool {
+	return isCompatible(slog.Default(), clientVersion, serverVersion)
+}
+
+// isCompatible is IsCompatible with an explicit logger, so warnings from the
+// version check reach the logger configured on Config.
+func isCompatible(logger *slog.Logger, clientVersion, serverVersion string) bool {
 	if clientVersion == serverVersion {
 		return true
 	}
-	logger := slog.Default()
 	client, err := ParseVersion(clientVersion)
 	if err != nil {
 		logger.Warn("Unable to compare versions", "err", err)

--- a/qdrant/config.go
+++ b/qdrant/config.go
@@ -68,6 +68,17 @@ type Config struct {
 	VersionCheckTimeout time.Duration
 	// Headers specifies optional headers to send with every gRPC request.
 	Headers map[string]string
+	// Logger used for client-side warnings such as a failed server version check.
+	// If nil, slog.Default() is used.
+	Logger *slog.Logger
+}
+
+// Internal method.
+func (c *Config) getLogger() *slog.Logger {
+	if c.Logger != nil {
+		return c.Logger
+	}
+	return slog.Default()
 }
 
 // Internal method.
@@ -119,7 +130,7 @@ func (c *Config) getTransportCreds() grpc.DialOption {
 		}
 		return grpc.WithTransportCredentials(credentials.NewTLS(c.TLSConfig))
 	} else if c.APIKey != "" {
-		slog.Default().Warn("API key is being used without TLS(HTTPS). It will be transmitted in plaintext.")
+		c.getLogger().Warn("API key is being used without TLS(HTTPS). It will be transmitted in plaintext.")
 	}
 	return grpc.WithTransportCredentials(insecure.NewCredentials())
 }

--- a/qdrant/grpc_client.go
+++ b/qdrant/grpc_client.go
@@ -2,7 +2,6 @@ package qdrant
 
 import (
 	"fmt"
-	"log/slog"
 	"runtime/debug"
 
 	"google.golang.org/grpc"
@@ -62,13 +61,14 @@ func NewGrpcClient(config *Config) (*GrpcClient, error) {
 	newGrpcClientFromConn := NewGrpcClientFromConn(conn)
 
 	if !config.SkipCompatibilityCheck {
-		serverVersion := getServerVersion(newGrpcClientFromConn, config.getVersionCheckTimeout())
-		logger := slog.Default()
-		if serverVersion == unknownVersion {
-			logger.Warn("Failed to obtain server version. " +
-				"Unable to check client-server compatibility. " +
-				"Set SkipCompatibilityCheck=true to skip version check.")
-		} else if !IsCompatible(clientVersion, serverVersion) {
+		logger := config.getLogger()
+		serverVersion, err := getServerVersion(newGrpcClientFromConn, config.getVersionCheckTimeout())
+		if err != nil {
+			logger.Warn("Failed to obtain server version. "+
+				"Unable to check client-server compatibility. "+
+				"Set SkipCompatibilityCheck=true to skip version check.",
+				"err", err)
+		} else if !isCompatible(logger, clientVersion, serverVersion) {
 			logger.Warn("Client version is not compatible with server version. "+
 				"Major versions should match and minor version difference must not exceed 1. "+
 				"Set SkipCompatibilityCheck=true to skip version check.",

--- a/qdrant_test/compare_versions_test.go
+++ b/qdrant_test/compare_versions_test.go
@@ -1,9 +1,19 @@
 package qdrant_test
 
 import (
+	"bytes"
+	"log/slog"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/qdrant/go-client/qdrant"
+)
+
+const (
+	// Nothing listens on port 1 locally, so the dial is refused right away.
+	unreachablePort     = 1
+	versionProbeTimeout = 100 * time.Millisecond
 )
 
 func TestParseVersion(t *testing.T) {
@@ -64,6 +74,26 @@ func TestIsCompatible(t *testing.T) {
 		result := qdrant.IsCompatible(clientVersion, serverVersion)
 		if result != test.expected {
 			t.Errorf("IsCompatible(%q, %q) = %v, want %v", clientVersion, serverVersion, result, test.expected)
+		}
+	}
+}
+
+func TestNewGrpcClientLogsVersionProbeFailure(t *testing.T) {
+	var buf bytes.Buffer
+	client, err := qdrant.NewGrpcClient(&qdrant.Config{
+		Port:                unreachablePort,
+		VersionCheckTimeout: versionProbeTimeout,
+		Logger:              slog.New(slog.NewTextHandler(&buf, nil)),
+	})
+	if err != nil {
+		t.Fatalf("NewGrpcClient() error = %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	got := buf.String()
+	for _, want := range []string{"Failed to obtain server version", "server health check failed"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("log output missing %q, got: %q", want, got)
 		}
 	}
 }


### PR DESCRIPTION
## summary

on client creation, the server version probe swallowed its error: `getServerVersion` logged with `slog.Default()` and returned `"Unknown"`, then `NewGrpcClient` logged a second warning without the cause. Two log lines, real error buried, no way to route them through the application's logger

### changes:

- `getServerVersion` returns `(string, error)` instead of logging and returning a sentinel. `NewGrpcClient` logs once, with the wrapped cause as `err` attribute
- new optional `Config.Logger *slog.Logger`. Nil falls back to `slog.Default()`, so no behavior change for existing callers. Version probe failure, version mismatch, version parse warnings and the plaintext API key warning all go through it
- `IsCompatible` keeps its public signature; internal `isCompatible` takes the logger
- added `TestNewGrpcClientLogsVersionProbeFailure`: dials a refused port, asserts the warning and wrapped health check error land in an injected logger