### PR TITLE
fix: clamp retry backoff before Duration conversion to avoid overflow

### DIFF
--- a/qdrant/retry.go
+++ b/qdrant/retry.go
@@ -93,7 +93,9 @@ const backoffBase = 2.0
 // backoffDuration computes an exponential backoff with full jitter.
 func (rc *RetryConfig) backoffDuration(attempt uint) time.Duration {
 	exp := math.Pow(backoffBase, float64(attempt))
-	backoff := min(time.Duration(float64(rc.baseBackoff())*exp), rc.maxBackoff())
+	// Clamp in float64 before converting: past roughly 2^37 the product exceeds
+	// int64 and the Duration conversion would wrap to a negative value.
+	backoff := time.Duration(min(float64(rc.baseBackoff())*exp, float64(rc.maxBackoff())))
 	// Full jitter: uniform random in [0, backoff).
 	if backoff > 0 {
 		backoff = time.Duration(rand.Int64N(int64(backoff)))


### PR DESCRIPTION
## summary

`backoffDuration` computes `base * 2^attempt` as a float, converts it to `time.Duration`, and only then caps it at `MaxBackoff`

by attempt 37 the product no longer fits in int64. Go's float-to-int conversion wraps instead of erroring, so the value becomes `math.MinInt64`. `min()` then keeps that negative value as the "smaller" one, the `backoff > 0` jitter guard is skipped, and `time.NewTimer` with a negative duration fires immediately. From that point every retry runs with zero delay: the backoff silently turns into a hot loop.

Fix: apply the `MaxBackoff` cap while the value is still a float, then convert. The result is always within `[0, MaxBackoff]`, so the conversion cannot overflow.

Only reachable with `RetryConfig.MaxRetries >= 37`. No API change.