### PR TITLE
fix: keep gRPC status reachable from QdrantResourceExhaustedError

### DIFF
--- a/qdrant/config.go
+++ b/qdrant/config.go
@@ -165,8 +165,9 @@ func (c *Config) getRateLimitInterceptor() grpc.DialOption {
 			parsed, parseErr := strconv.Atoi(values[0])
 			if parseErr == nil {
 				return &QdrantResourceExhaustedError{
-					st.Message(),
-					parsed,
+					Reason:      st.Message(),
+					RetryAfterS: parsed,
+					err:         err,
 				}
 			}
 			return errors.Join(fmt.Errorf("parse retry-after header %q: %w", values[0], parseErr), err)

--- a/qdrant/error.go
+++ b/qdrant/error.go
@@ -38,8 +38,7 @@ func newQdrantErr(err error, operationName string, contexts ...string) *QdrantEr
 type QdrantResourceExhaustedError struct {
 	Reason      string
 	RetryAfterS int
-	// err is the original gRPC status error, kept so status.Code(err) and
-	// errors.As still see codes.ResourceExhausted.
+	// the original gRPC status error
 	err error
 }
 
@@ -47,7 +46,6 @@ func (e *QdrantResourceExhaustedError) Error() string {
 	return fmt.Sprintf("ResourceExhausted: %s, retry after %d seconds", e.Reason, e.RetryAfterS)
 }
 
-// Unwrap returns the underlying gRPC status error.
 func (e *QdrantResourceExhaustedError) Unwrap() error {
 	return e.err
 }

--- a/qdrant/error.go
+++ b/qdrant/error.go
@@ -38,8 +38,16 @@ func newQdrantErr(err error, operationName string, contexts ...string) *QdrantEr
 type QdrantResourceExhaustedError struct {
 	Reason      string
 	RetryAfterS int
+	// err is the original gRPC status error, kept so status.Code(err) and
+	// errors.As still see codes.ResourceExhausted.
+	err error
 }
 
 func (e *QdrantResourceExhaustedError) Error() string {
 	return fmt.Sprintf("ResourceExhausted: %s, retry after %d seconds", e.Reason, e.RetryAfterS)
+}
+
+// Unwrap returns the underlying gRPC status error.
+func (e *QdrantResourceExhaustedError) Unwrap() error {
+	return e.err
 }


### PR DESCRIPTION
## summary

the rate-limit interceptor replaces the server's `ResourceExhausted` error with `QdrantResourceExhaustedError` so callers can read `RetryAfterS`. The wrapper dropped the original error and had no `Unwrap`, so `status.Code(err)` returned `codes.Unknown` instead of `codes.ResourceExhausted`. Any rate-limit handling written against gRPC codes silently stopped matching.

Fix: keep the original status error inside the wrapper and add `Unwrap()`. `status.Code` and `errors.As` now both work on the same error. No public field changes

Verified with an in-process gRPC server returning `ResourceExhausted` with a `retry-after` trailer: `status.Code` is `Unknown` on master, `ResourceExhausted` with this change