### PR TITLE
chore: return all connection close errors from Client.Close

### DIFF
--- a/qdrant/client.go
+++ b/qdrant/client.go
@@ -1,6 +1,7 @@
 package qdrant
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 	"sync"
@@ -104,16 +105,17 @@ func (c *Client) GetConnection() *grpc.ClientConn {
 }
 
 // Close tears down all underlying connections.
+// If several connections fail to close, all errors are returned joined.
 func (c *Client) Close() error {
-	var lastErr error
+	var errs []error
 	c.closeOnce.Do(func() {
 		for _, client := range c.clients {
 			if err := client.Close(); err != nil {
-				lastErr = err
+				errs = append(errs, err)
 			}
 		}
 	})
-	return lastErr
+	return errors.Join(errs...)
 }
 
 // Creates a pointer to a value of any type.


### PR DESCRIPTION
## summary

`Client.Close` loops over the pooled gRPC connections but only keeps the last error. If an earlier connection fails to close and the last one succeeds, `Close` returns nil and the failure is lost. If several fail, only one is reported.

Fix: collect the errors and return `errors.Join(errs...)`. With no failures it still returns nil, so the happy path is unchanged. `errors.Is` and `errors.As` see every joined error.

Verified locally with a pool of 3 pre-closed connections: master returns 1 error, this change returns all 3.